### PR TITLE
feat: Add command to generate skeleton for Barq strategy

### DIFF
--- a/barq-common/create_strategy.sh
+++ b/barq-common/create_strategy.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+capitalize() {
+    echo "$1" | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}'
+}
+
+script_dir=$(dirname "$(realpath "$0")")
+
+mkdir -p "$script_dir/src/algorithms"
+
+read -p "Enter the name of your strategy: " script_name
+
+capitalized_script_name=$(capitalize "$script_name")
+
+if [ -f "$script_dir/src/algorithms/${script_name}.rs" ]; then
+    echo "Error: $script_dir/src/algorithms/${script_name}.rs already exists."
+    exit 1
+fi
+
+cat <<EOL > "$script_dir/src/algorithms/${script_name}.rs"
+use anyhow::Result;
+
+use crate::strategy::{RouteHop, RouteInput, RouteOutput, Strategy};
+
+const DEFAULT_DELAY: u64 = 9;
+
+pub struct $capitalized_script_name;
+
+impl $capitalized_script_name {
+    pub fn new() -> Self {
+        $capitalized_script_name 
+    }
+}
+
+impl Default for $capitalized_script_name {
+    fn default() -> Self {
+        $capitalized_script_name::new()
+    }
+}
+
+impl Strategy for $capitalized_script_name {
+    fn can_apply(&self, input: &RouteInput) -> Result<bool> {
+        // TODO: implement logic which checks if this strategy can be applied to given network graph
+    }
+
+    fn route(&self, input: &RouteInput) -> Result<RouteOutput> {
+        // TODO: implement routing algorithm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        graph::{Edge, NetworkGraph, Node},
+        strategy::Router,
+    };
+
+    #[test]
+    fn test_direct_routing() {
+        // TODO: write tests for $capitalized_script_name strategy
+    }
+}
+EOL
+
+echo "Strategy ${script_name} created in $script_dir/src/algorithms/${script_name}.rs"


### PR DESCRIPTION
Currently, developers need to manually write the skeleton for a new Barq strategy from scratch. This change introduces a new command that automates the creation of the skeleton for a Barq strategy. This enhancement streamlines the development process by providing a ready-to-use template, allowing developers to focus on implementing the strategy logic.

- Add command to generate Barq strategy skeleton
- Include necessary placeholders and structure in the generated skeleton

solves #14 