### PR TITLE
meta: build the plugin before run checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ fmt:
 	$(CC) fmt --all
 
 check:
+	$(CC) build
 	$(CC) test --all
 	cd tests; poetry run pytest . -s -x
 


### PR DESCRIPTION
Fixing the following check inside the CI

```
test_simple.py Running tests in /tmp/ltests-exfe8owm lightningd: --plugin=/home/vincent/github/work/sob2024/barq/tests/../target/debug/barq-plugin: Failed to register /home/vincent/github/work/sob2024/barq/tests/../target/debug/barq-plugin: No such file or directory
```

The problem was that we were not building the plugin before running the check, this does not make sense because often we want to run the tests on the last version of the plugin