### PR TITLE
Make amount_msat parameter optional in barqpay RPC call

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "attach",
+            "name": "Debug",
+            "pid": "24818"
+        },
+    ]
+}

--- a/barq-common/src/graph.rs
+++ b/barq-common/src/graph.rs
@@ -106,8 +106,9 @@ impl NetworkGraph {
     /// Adds an edge (channel) to the network graph.
     pub fn add_edge(&mut self, edge: Edge) {
         self.edges.insert(edge.id.clone(), edge.clone());
-        self.nodes.get_mut(&edge.node1).unwrap().add_channel(&edge);
-        self.nodes.get_mut(&edge.node2).unwrap().add_channel(&edge);
+        if let Some(source_node) = self.nodes.get_mut(&edge.clone().node1) {
+            source_node.add_channel(&edge);
+        }
     }
 
     /// Gets a reference to a node by its ID.

--- a/barq-plugin/src/methods/utils/graph.rs
+++ b/barq-plugin/src/methods/utils/graph.rs
@@ -41,9 +41,6 @@ pub fn build_network_graph(state: &State) -> Result<NetworkGraph, PluginError> {
         if graph.get_node(&channel.source).is_none() {
             graph.add_node(Node::new(&channel.source));
         }
-        if graph.get_node(&channel.destination).is_none() {
-            graph.add_node(Node::new(&channel.destination));
-        }
 
         // Convert amount_msat to u64
         let amount_msat = channel.amount_msat;

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,6 +1,8 @@
 import os
 
 from pyln.testing.fixtures import *  # noqa: F403
+from pyln.testing.utils import only_one
+from pyln.client import Millisatoshi
 
 barq_binary = os.path.join(os.path.dirname(__file__), "../target/debug/barq-plugin")
 
@@ -14,3 +16,32 @@ def test_init(node_factory):
         }
     )
     assert True
+
+
+def test_pay_amounts(node_factory):
+    """We steal this from core lightning test_pay.py, and we are try just 
+    to pay and invoice with amount"""
+    l1, l2 = node_factory.line_graph(2, opts=[{"plugin": barq_binary }, { "plugin": barq_binary}], wait_for_announce=True)
+    inv = l2.rpc.invoice(Millisatoshi("123sat"), 'test_pay_amounts', 'description')['bolt11']
+
+    invoice = only_one(l2.rpc.listinvoices('test_pay_amounts')['invoices'])
+
+    assert invoice['amount_msat'] == Millisatoshi(123000)
+
+    l1.rpc.call("barqpay", {"bolt11_invoice": inv})
+
+    invoice = only_one(l2.rpc.listinvoices('test_pay_amounts')['invoices'])
+    assert invoice['amount_received_msat'] >= Millisatoshi(123000)
+
+
+def test_pay_without_amounts(node_factory):
+    """We are going to test that we can pay an invoice without amount"""
+    l1, l2 = node_factory.line_graph(2, opts=[{"plugin": barq_binary }, { "plugin": barq_binary}], wait_for_announce=True)
+    inv = l2.rpc.invoice("any", 'test_pay_amounts', 'description')['bolt11']
+
+    invoice = only_one(l2.rpc.listinvoices('test_pay_amounts')['invoices'])
+
+    l1.rpc.call("barqpay", {"bolt11_invoice": inv, "amount_msat": 123000})
+
+    invoice = only_one(l2.rpc.listinvoices('test_pay_amounts')['invoices'])
+    assert invoice['amount_received_msat'] >= Millisatoshi(123000)


### PR DESCRIPTION
Feature added: Optional amount_msat for lightning payments in Barq

- Users can now make lightning payments with invoices that do not specify an amount.
